### PR TITLE
Ipv6Addr::new takes u16 segments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ pub fn ssdp_probe_v6(
         SocketAddr::new(IpAddr::from(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)), 1900),
         SsdpMSearch {
             host: SocketAddr::new(
-                IpAddr::from(Ipv6Addr::new(0xFF, 0x02, 0, 0, 0, 0, 0, 0xC)),
+                IpAddr::from(Ipv6Addr::new(0xFF02, 0, 0, 0, 0, 0, 0, 0xC)),
                 1900,
             ),
             mx: 3,
@@ -98,7 +98,7 @@ pub fn ssdp_probe_v6(
             extra_lines: "",
         },
         SocketAddr::new(
-            IpAddr::from(Ipv6Addr::new(0xFF, 0x02, 0, 0, 0, 0, 0, 0xC)),
+            IpAddr::from(Ipv6Addr::new(0xFF02, 0, 0, 0, 0, 0, 0, 0xC)),
             1900,
         ),
         Domain::ipv6(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,7 @@ ST: {}
 "#,
             self.host, self.mx, self.st, self.extra_lines
         )
+        .replace("\n", "\r\n")
         .into_bytes()
     }
 }


### PR DESCRIPTION
Ipv6Addr::new takes u16 segments as can be seen here: https://doc.rust-lang.org/std/net/struct.Ipv6Addr.html#method.new

so the FF02::C address is `Ipv6Addr::new(0xFF02, 0, 0, 0, 0, 0, 0, 0xC)`

the current `Ipv6Addr::new(0xFF, 0x02, 0, 0, 0, 0, 0, 0xC)` is actually `00ff:0002::c` and gives the following error:
```
Error: Io(Os { code: 101, kind: NetworkUnreachable, message: "Network is unreachable" })
```

ps.
also, payload needs to be CRLF delimited